### PR TITLE
Add podcast page route

### DIFF
--- a/public/podcast.html
+++ b/public/podcast.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="RepSpheres Podcast: Sales insights and strategies"
+    />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>RepSpheres Podcast</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/src/PodcastPage.js
+++ b/src/PodcastPage.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Box, Typography, Container } from '@mui/material';
+import Podcasts from './components/Podcasts';
+
+export default function PodcastPage() {
+  return (
+    <>
+      <Box
+        sx={{
+          py: { xs: 8, md: 12 },
+          background: 'linear-gradient(135deg, #7B42F6 0%, #00ffc6 100%)',
+          color: '#fff',
+          textAlign: 'center',
+        }}
+      >
+        <Container maxWidth="md">
+          <Typography variant="h2" fontWeight={800} gutterBottom>
+            RepSpheres Podcast
+          </Typography>
+          <Typography variant="h6" sx={{ color: 'rgba(255,255,255,0.9)' }}>
+            Insights, interviews and strategies for elite sales reps.
+          </Typography>
+        </Container>
+      </Box>
+      <Podcasts />
+    </>
+  );
+}

--- a/src/PodcastPage.test.js
+++ b/src/PodcastPage.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import PodcastPage from './PodcastPage';
+
+test('renders podcast title', () => {
+  render(<PodcastPage />);
+  const titleElement = screen.getByText(/RepSpheres Podcast/i);
+  expect(titleElement).toBeInTheDocument();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import PodcastPage from './PodcastPage';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    {window.location.pathname === '/podcast.html' ? (
+      <PodcastPage />
+    ) : (
+      <App />
+    )}
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- create `<PodcastPage>` and hero section using existing Podcasts component
- duplicate `public/index.html` -> `public/podcast.html` with podcast metadata
- show `PodcastPage` when `/podcast.html` is loaded
- add test for PodcastPage rendering

## Testing
- `npm test --silent` *(fails: react-scripts not found)*