### PR TITLE
Wrap NavBar in fragment and reduce modal size

### DIFF
--- a/src/components/InfoModal.js
+++ b/src/components/InfoModal.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
+
+/**
+ * InfoModal - reusable modal component with RepSpheres styling
+ *
+ * Props:
+ *  - open: boolean to control visibility
+ *  - onClose: function to close the modal
+ *  - title: title text for the modal
+ *  - children: content of the modal
+ */
+export default function InfoModal({ open, onClose, title, children, maxWidth = 'xs' }) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth={maxWidth}
+      fullWidth
+      PaperProps={{
+        sx: {
+          background: 'rgba(20,14,38,0.96)',
+          border: '1px solid rgba(123,66,246,0.4)',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.35)',
+          borderRadius: 3,
+          color: '#fff',
+        }
+      }}
+    >
+      <DialogTitle
+        sx={{
+          fontWeight: 700,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        {title}
+        <IconButton onClick={onClose} size="small" sx={{ color: '#fff' }}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ borderColor: 'rgba(255,255,255,0.1)' }}>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -26,6 +26,8 @@ import MenuItem from '@mui/material/MenuItem';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
+import InfoModal from './InfoModal';
 
 const ACCENT_COLOR = '#00ffc6';
 
@@ -72,17 +74,18 @@ const getNavLinks = (currentUrl) => {
   return links;
 };
 
-// More menu items
+// More menu items for additional information
 const moreMenuItems = [
-  { label: 'About RepSpheres', href: 'https://repspheres.com/about' },
-  { label: 'Contact', href: 'https://repspheres.com/contact' },
-  { label: 'Careers', href: 'https://repspheres.com/careers' },
-  { label: 'Legal', href: 'https://repspheres.com/legal' }
+  { key: 'about', label: 'About RepSpheres' },
+  { key: 'contact', label: 'Contact' },
+  { key: 'careers', label: 'Careers' },
+  { key: 'legal', label: 'Legal' }
 ];
 
 export default function NavBar() {
   const [drawerOpen, setDrawerOpen] = React.useState(false);
   const [menuAnchorEl, setMenuAnchorEl] = React.useState(null);
+  const [openInfo, setOpenInfo] = React.useState(null); // which info modal is open
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
@@ -125,6 +128,16 @@ export default function NavBar() {
 
   const handleMenuClose = () => {
     setMenuAnchorEl(null);
+  };
+
+  // Open information modal from more menu or drawer
+  const handleInfoOpen = (key) => {
+    handleMenuClose();
+    setOpenInfo(key);
+  };
+
+  const handleInfoClose = () => {
+    setOpenInfo(null);
   };
   
   // Styles for different button types
@@ -256,9 +269,8 @@ export default function NavBar() {
         {moreMenuItems.map((item, index) => (
           <ListItem key={index} disablePadding sx={{ mb: 0.5 }}>
             <ListItemButton
-              component="a"
-              href={item.href}
-              sx={{ 
+              onClick={() => handleInfoOpen(item.key)}
+              sx={{
                 py: 0.75,
                 px: 2,
                 borderRadius: '8px',
@@ -269,8 +281,6 @@ export default function NavBar() {
             </ListItemButton>
           </ListItem>
         ))}
-        
-
       </List>
       
       {/* Auth Buttons */}
@@ -307,6 +317,7 @@ export default function NavBar() {
   );
 
   return (
+    <>
     <AppBar position="sticky" elevation={0} sx={{
       background: 'rgba(24,24,43,0.52)',
       backdropFilter: 'blur(10px)',
@@ -522,11 +533,9 @@ export default function NavBar() {
 
             {/* More Menu Items */}
             {moreMenuItems.map((item, index) => (
-              <MenuItem 
-                key={index} 
-                component="a"
-                href={item.href}
-                onClick={handleMenuClose}
+              <MenuItem
+                key={index}
+                onClick={() => handleInfoOpen(item.key)}
                 sx={{ color: '#fff' }}
               >
                 {item.label}
@@ -545,5 +554,57 @@ export default function NavBar() {
         </Drawer>
       </Toolbar>
     </AppBar>
+
+    {/* Information Modals */}
+    <InfoModal
+      open={openInfo === 'about'}
+      onClose={handleInfoClose}
+      title="About RepSpheres"
+      maxWidth="xs"
+    >
+      <Typography variant="body1" sx={{ mb: 1 }}>
+        RepSpheres empowers elite sales teams with unified workflows and
+        actionable market intelligence.
+      </Typography>
+    </InfoModal>
+
+    <InfoModal
+      open={openInfo === 'contact'}
+      onClose={handleInfoClose}
+      title="Contact"
+      maxWidth="xs"
+    >
+      <Typography variant="body1" sx={{ mb: 1 }}>
+        Reach us at <a href="mailto:contact@repspheres.com">contact@repspheres.com</a>
+        {' '}to learn more or schedule a call.
+      </Typography>
+    </InfoModal>
+
+    <InfoModal
+      open={openInfo === 'careers'}
+      onClose={handleInfoClose}
+      title="Careers"
+      maxWidth="xs"
+    >
+      <Typography variant="body1" sx={{ mb: 1 }}>
+        We're always looking for talent passionate about sales technology.
+        Send your resume to{' '}
+        <a href="mailto:careers@repspheres.com">careers@repspheres.com</a>.
+      </Typography>
+    </InfoModal>
+
+    <InfoModal
+      open={openInfo === 'legal'}
+      onClose={handleInfoClose}
+      title="Legal"
+      maxWidth="xs"
+    >
+      <Typography variant="body1">
+        Use of RepSpheres is subject to our{' '}
+        <a href="/terms.html">Terms of Service</a> and{' '}
+        <a href="/privacy.html">Privacy Policy</a>.
+      </Typography>
+    </InfoModal>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- allow `InfoModal` size via `maxWidth` prop
- wrap `NavBar` return content in fragment
- show About, Contact, Careers, and Legal modals with smaller width

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build:netlify` *(fails: react-scripts not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.