### PR TITLE
Add podcast page route

### DIFF
--- a/public/podcast.html
+++ b/public/podcast.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="RepSpheres Podcast: Sales insights and strategies"
+    />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>RepSpheres Podcast</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/src/PodcastPage.js
+++ b/src/PodcastPage.js
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Typography, Container } from '@mui/material';
+import NavBar from './components/NavBar';
+import StarryBackground from './components/StarryBackground';
+import OrbContextProvider from './components/OrbContextProvider';
+import Podcasts from './components/Podcasts';
+
+const SUPABASE_URL = process.env.REACT_APP_SUPABASE_URL;
+const SUPABASE_KEY = process.env.REACT_APP_SUPABASE_KEY;
+
+export default function PodcastPage() {
+  const [episodes, setEpisodes] = useState([]);
+
+  useEffect(() => {
+    const fetchEpisodes = async () => {
+      if (!SUPABASE_URL || !SUPABASE_KEY) return;
+      try {
+        const res = await fetch(`${SUPABASE_URL}/rest/v1/podcasts?select=*`, {
+          headers: {
+            apikey: SUPABASE_KEY,
+            Authorization: `Bearer ${SUPABASE_KEY}`,
+          },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setEpisodes(data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch podcasts', err);
+      }
+    };
+
+    fetchEpisodes();
+  }, []);
+
+  return (
+    <OrbContextProvider>
+      <StarryBackground />
+      <NavBar />
+      <Box
+        sx={{
+          py: { xs: 8, md: 12 },
+          background: 'linear-gradient(135deg, #7B42F6 0%, #00ffc6 100%)',
+          color: '#fff',
+          textAlign: 'center',
+        }}
+      >
+        <Container maxWidth="md">
+          <Typography variant="h2" fontWeight={800} gutterBottom>
+            RepSpheres Podcast
+          </Typography>
+          <Typography variant="h6" sx={{ color: 'rgba(255,255,255,0.9)' }}>
+            Insights, interviews and strategies for elite sales reps.
+          </Typography>
+        </Container>
+      </Box>
+      <Podcasts episodes={episodes} />
+    </OrbContextProvider>
+  );
+}

--- a/src/PodcastPage.test.js
+++ b/src/PodcastPage.test.js
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import PodcastPage from './PodcastPage';
+
+test('renders podcast title and hides nav podcast link', () => {
+  render(<PodcastPage />);
+  const titleElement = screen.getByText(/RepSpheres Podcast/i);
+  expect(titleElement).toBeInTheDocument();
+  const podcastLink = screen.queryByRole('link', { name: /podcast/i });
+  expect(podcastLink).toBeNull();
+});

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -51,24 +51,29 @@ const getNavLinks = (currentUrl) => {
       href: 'https://crm.repspheres.com/',
       icon: <MemoryIcon fontSize="small" sx={{ color: ACCENT_COLOR }} />
     },
-    { 
+    {
       key: 'podcast',
-      label: 'Podcast', 
+      label: 'Podcast',
       href: '/podcast.html',
       icon: <PodcastsIcon fontSize="small" sx={{ color: ACCENT_COLOR }} />
     },
   ];
-  
+
   // Show Linguistics link only if not on the linguistics page
   if (!currentUrl.includes('/linguistics')) {
-    links.splice(2, 0, { 
+    links.splice(2, 0, {
       key: 'linguistics',
-      label: 'Linguistics', 
+      label: 'Linguistics',
       href: 'https://linguistics.repspheres.com/',
       icon: <LanguageIcon fontSize="small" sx={{ color: ACCENT_COLOR }} />
     });
   }
-  
+
+  // Hide podcast link when already on the podcast page
+  if (currentUrl.includes('/podcast.html')) {
+    return links.filter((l) => l.key !== 'podcast');
+  }
+
   return links;
 };
 

--- a/src/components/Podcasts.js
+++ b/src/components/Podcasts.js
@@ -2,26 +2,38 @@ import React from 'react';
 import { Box, Typography, Container, Button } from '@mui/material';
 import PodcastsIcon from '@mui/icons-material/Podcasts';
 
-export default function Podcasts() {
+export default function Podcasts({ episodes = [] }) {
   return (
     <Box sx={{ py: 6, background: 'rgba(40, 20, 70, 0.55)', color: '#fff' }}>
-      <Container maxWidth="md" sx={{ textAlign: 'center' }}>
+      <Container maxWidth="md" sx={{ textAlign: 'center', mb: 4 }}>
         <PodcastsIcon sx={{ fontSize: 60, color: 'var(--secondary, #00ffc6)' }} />
         <Typography variant="h4" fontWeight={700} gutterBottom>
-          Listen to Our Podcast
+          Latest Episodes
         </Typography>
-        <Typography variant="body1" color="text.secondary" gutterBottom>
-          Deep dives, interviews, and actionable insights from industry leaders.
-        </Typography>
-        <Button
-          variant="contained"
-          color="secondary"
-          size="large"
-          href="#"
-          sx={{ mt: 2 }}
-        >
-          Go to Podcasts
-        </Button>
+      </Container>
+      <Container maxWidth="md">
+        {episodes.length === 0 && (
+          <Typography align="center" color="text.secondary">
+            No episodes available.
+          </Typography>
+        )}
+        {episodes.map((ep) => (
+          <Box key={ep.id} sx={{ mb: 3, textAlign: 'left' }}>
+            <Typography variant="h6" fontWeight={600} gutterBottom>
+              {ep.title}
+            </Typography>
+            {ep.description && (
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                {ep.description}
+              </Typography>
+            )}
+            {ep.url && (
+              <Button variant="outlined" href={ep.url} size="small">
+                Listen
+              </Button>
+            )}
+          </Box>
+        ))}
       </Container>
     </Box>
   );

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import PodcastPage from './PodcastPage';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    {window.location.pathname === '/podcast.html' ? (
+      <PodcastPage />
+    ) : (
+      <App />
+    )}
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- create `<PodcastPage>` and hero section using existing Podcasts component
- duplicate `public/index.html` -> `public/podcast.html` with podcast metadata
- show `PodcastPage` when `/podcast.html` is loaded
- add test for PodcastPage rendering
- integrate navbar and hide podcast link if already on podcast page
- fetch episodes from Supabase in Podcasts component

## Testing
- `npm test --silent` *(fails: react-scripts not found)*