### PR TITLE
Add glass auth modals

### DIFF
--- a/src/components/AuthModal.js
+++ b/src/components/AuthModal.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Box, TextField, Button } from '@mui/material';
+import InfoModal from './InfoModal';
+
+/**
+ * AuthModal - login or signup form inside InfoModal
+ *
+ * Props:
+ *  - open: boolean to control visibility
+ *  - onClose: function to close the modal
+ *  - mode: 'login' or 'signup'
+ */
+export default function AuthModal({ open, onClose, mode = 'login' }) {
+  const isLogin = mode === 'login';
+
+  return (
+    <InfoModal
+      open={open}
+      onClose={onClose}
+      title={isLogin ? 'Log In' : 'Sign Up'}
+      maxWidth="xs"
+    >
+      <Box
+        component="form"
+        noValidate
+        sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}
+      >
+        <TextField
+          label="Email"
+          type="email"
+          fullWidth
+          variant="filled"
+          InputProps={{ style: { background: 'rgba(255,255,255,0.1)' } }}
+        />
+        <TextField
+          label="Password"
+          type="password"
+          fullWidth
+          variant="filled"
+          InputProps={{ style: { background: 'rgba(255,255,255,0.1)' } }}
+        />
+        {!isLogin && (
+          <TextField
+            label="Confirm Password"
+            type="password"
+            fullWidth
+            variant="filled"
+            InputProps={{ style: { background: 'rgba(255,255,255,0.1)' } }}
+          />
+        )}
+        <Button variant="contained" color="primary">
+          {isLogin ? 'Log In' : 'Sign Up'}
+        </Button>
+      </Box>
+    </InfoModal>
+  );
+}

--- a/src/components/InfoModal.js
+++ b/src/components/InfoModal.js
@@ -16,21 +16,37 @@ import CloseIcon from '@mui/icons-material/Close';
  */
 export default function InfoModal({ open, onClose, title, children, maxWidth = 'xs' }) {
   return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      maxWidth={maxWidth}
-      fullWidth
-      PaperProps={{
-        sx: {
-          background: 'rgba(20,14,38,0.96)',
-          border: '1px solid rgba(123,66,246,0.4)',
-          boxShadow: '0 8px 32px rgba(0,0,0,0.35)',
-          borderRadius: 3,
-          color: '#fff',
-        }
-      }}
-    >
+      <Dialog
+        open={open}
+        onClose={onClose}
+        maxWidth={maxWidth}
+        fullWidth
+        PaperProps={{
+          sx: {
+            position: 'relative',
+            background: 'rgba(20,14,38,0.75)',
+            backdropFilter: 'blur(12px)',
+            borderRadius: 3,
+            color: '#fff',
+            overflow: 'hidden',
+            boxShadow:
+              '0 0 0 2px rgba(0,255,198,0.6), 0 0 20px rgba(123,66,246,0.45)',
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              inset: 0,
+              padding: '2px',
+              borderRadius: 3,
+              background:
+                'linear-gradient(135deg, rgba(123,66,246,0.8), rgba(0,255,198,0.8))',
+              WebkitMask:
+                'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+              WebkitMaskComposite: 'xor',
+              pointerEvents: 'none',
+            },
+          },
+        }}
+      >
       <DialogTitle
         sx={{
           fontWeight: 700,

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -28,6 +28,7 @@ import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
 import InfoModal from './InfoModal';
+import AuthModal from './AuthModal';
 
 const ACCENT_COLOR = '#00ffc6';
 
@@ -91,6 +92,7 @@ export default function NavBar() {
   const [drawerOpen, setDrawerOpen] = React.useState(false);
   const [menuAnchorEl, setMenuAnchorEl] = React.useState(null);
   const [openInfo, setOpenInfo] = React.useState(null); // which info modal is open
+  const [openAuth, setOpenAuth] = React.useState(null); // 'login' or 'signup'
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
@@ -143,6 +145,15 @@ export default function NavBar() {
 
   const handleInfoClose = () => {
     setOpenInfo(null);
+  };
+
+  // Open and close auth modals
+  const handleAuthOpen = (mode) => {
+    setOpenAuth(mode);
+  };
+
+  const handleAuthClose = () => {
+    setOpenAuth(null);
   };
 
   // Sign out handler
@@ -305,10 +316,9 @@ export default function NavBar() {
       
       {/* Auth Buttons */}
       <Box sx={{ mt: 4, px: 1 }}>
-        <Button 
-          fullWidth 
-          component="a" 
-          href="/login.html"
+        <Button
+          fullWidth
+          onClick={() => handleAuthOpen('login')}
           variant="outlined"
           sx={{
             ...loginButtonStyles,
@@ -321,8 +331,7 @@ export default function NavBar() {
         
         <Button
           fullWidth
-          component="a"
-          href="/signup.html"
+          onClick={() => handleAuthOpen('signup')}
           variant="contained"
           sx={{
             ...signupButtonStyles,
@@ -488,8 +497,7 @@ export default function NavBar() {
             alignItems: 'center',
           }}>
             <Button
-              component="a"
-              href="/login.html"
+              onClick={() => handleAuthOpen('login')}
               variant="outlined"
               sx={loginButtonStyles}
             >
@@ -497,8 +505,7 @@ export default function NavBar() {
             </Button>
             
             <Button
-              component="a"
-              href="/signup.html"
+              onClick={() => handleAuthOpen('signup')}
               variant="contained"
               sx={signupButtonStyles}
             >
@@ -595,6 +602,18 @@ export default function NavBar() {
         </Drawer>
       </Toolbar>
     </AppBar>
+
+    {/* Auth Modals */}
+    <AuthModal
+      open={openAuth === 'login'}
+      onClose={handleAuthClose}
+      mode="login"
+    />
+    <AuthModal
+      open={openAuth === 'signup'}
+      onClose={handleAuthClose}
+      mode="signup"
+    />
 
     {/* Information Modals */}
     <InfoModal


### PR DESCRIPTION
## Summary
- add `AuthModal` component for log in and sign up
- style `InfoModal` with laser-like gradient border
- open auth modals from NavBar instead of linking to separate pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*