### PR TITLE
Add floating theme inverter

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import OrbContextProvider from './components/OrbContextProvider';
 import CTASection from './components/CTASection';
 import IntelligenceSection from './components/IntelligenceSection';
 import Footer from './components/Footer';
+import ThemeToggle from './components/ThemeToggle';
 
 function App() {
   return (
@@ -26,6 +27,7 @@ function App() {
 
       <CTASection />
       <Footer />
+      <ThemeToggle />
       {/* Add more sections/components as needed */}
     </OrbContextProvider>
   );

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -20,7 +20,6 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import MemoryIcon from '@mui/icons-material/Memory';
 import { useOrbContext } from './OrbContextProvider';
-import ThemeToggle from './ThemeToggle';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
@@ -472,16 +471,6 @@ export default function NavBar() {
           ml: 'auto',
           gap: { xs: 0.5, sm: 1 },
         }}>
-          {/* Theme Toggle - Subtle but visible */}
-          <Box sx={{
-            display: 'flex',
-            alignItems: 'center',
-            mr: 1,
-            opacity: 0.8,
-          }}>
-            <ThemeToggle />
-          </Box>
-          
           {/* Auth Buttons - Always visible except on very small screens */}
           <Box sx={{
             display: 'flex',

--- a/src/components/ThemeToggle.js
+++ b/src/components/ThemeToggle.js
@@ -1,37 +1,50 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import IconButton from '@mui/material/IconButton';
-import Brightness4Icon from '@mui/icons-material/Brightness4';
-import Brightness7Icon from '@mui/icons-material/Brightness7';
-import { useTheme } from '@mui/material/styles';
+import InvertColorsIcon from '@mui/icons-material/InvertColors';
 
 /**
- * ThemeToggle component for switching between light and dark themes
- * 
- * This component provides a toggle button to switch between light and dark modes.
- * It automatically adjusts its icon based on the current theme.
+ * Floating theme toggle that inverts the page colors.
  */
-export default function ThemeToggle({ onToggle }) {
-  const theme = useTheme();
-  const isDarkMode = theme.palette.mode === 'dark';
-  
-  // If no onToggle function is provided, use a placeholder
-  const handleToggle = onToggle || (() => {
-    console.log('Theme toggle clicked. To implement theme switching, pass an onToggle function.');
-  });
+export default function ThemeToggle() {
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('invertedTheme') === 'true';
+    setActive(stored);
+    if (stored) {
+      document.body.classList.add('inverted-theme');
+    }
+  }, []);
+
+  const handleToggle = () => {
+    const newVal = !active;
+    setActive(newVal);
+    if (newVal) {
+      document.body.classList.add('inverted-theme');
+    } else {
+      document.body.classList.remove('inverted-theme');
+    }
+    localStorage.setItem('invertedTheme', newVal);
+  };
 
   return (
-    <IconButton 
+    <IconButton
       onClick={handleToggle}
       color="inherit"
-      aria-label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-      sx={{ 
+      aria-label="Toggle color theme"
+      sx={{
+        position: 'fixed',
+        bottom: 16,
+        right: 16,
+        zIndex: 1500,
         color: '#fff',
+        backgroundColor: 'rgba(255,255,255,0.15)',
         '&:hover': {
-          backgroundColor: 'rgba(255,255,255,0.1)'
-        },
+          backgroundColor: 'rgba(255,255,255,0.25)'
+        }
       }}
     >
-      {isDarkMode ? <Brightness7Icon /> : <Brightness4Icon />}
+      <InvertColorsIcon />
     </IconButton>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,15 @@ body {
   overflow-x: hidden;
 }
 
+body.inverted-theme {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+body.inverted-theme img,
+body.inverted-theme video {
+  filter: invert(1) hue-rotate(180deg);
+}
+
 h1, h2, h3, h4, h5, h6 {
   margin-bottom: 1rem;
   line-height: 1.2;


### PR DESCRIPTION
## Summary
- remove unused theme toggle from NavBar
- create functional floating `ThemeToggle` button to invert site colors
- mount the new toggle in `App`
- add styles for inverted theme

## Testing
- `npm test` *(fails: react-scripts not found)*