### PR TITLE
Add basic login with provider buttons

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -10,10 +10,34 @@
       content="Login to RepSpheres"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
     <title>Login - RepSpheres</title>
   </head>
   <body>
-    <h1>Login Coming Soon</h1>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
   </body>
 </html>

--- a/public/signup.html
+++ b/public/signup.html
@@ -10,10 +10,34 @@
       content="Sign up for RepSpheres"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
     <title>Sign Up - RepSpheres</title>
   </head>
   <body>
-    <h1>Signup Coming Soon</h1>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
   </body>
 </html>

--- a/src/LoginPage.js
+++ b/src/LoginPage.js
@@ -1,11 +1,77 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import NavBar from './components/NavBar';
+import { Box, Button, Stack, TextField, Typography, Divider } from '@mui/material';
 
 export default function LoginPage() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const storedName = localStorage.getItem('name');
+    const storedEmail = localStorage.getItem('email');
+    if (storedName && storedEmail) {
+      setName(storedName);
+      setEmail(storedEmail);
+      setLoggedIn(true);
+    }
+  }, []);
+
+  const handleLogin = (e) => {
+    e.preventDefault();
+    if (name && email) {
+      localStorage.setItem('name', name);
+      localStorage.setItem('email', email);
+      setLoggedIn(true);
+    }
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('name');
+    localStorage.removeItem('email');
+    setName('');
+    setEmail('');
+    setLoggedIn(false);
+  };
+
+  const handleProvider = (provider) => {
+    // Placeholder for Google/Facebook login integrations
+    alert(`This would start the ${provider} login flow.`);
+  };
+
   return (
     <div>
       <NavBar />
-      <h1>Login</h1>
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Login
+        </Typography>
+        {loggedIn ? (
+          <Box>
+            <Typography sx={{ mb: 2 }}>
+              Logged in as {name} ({email})
+            </Typography>
+            <Button variant="contained" onClick={handleLogout}>
+              Log Out
+            </Button>
+          </Box>
+        ) : (
+          <Stack component="form" onSubmit={handleLogin} spacing={2} sx={{ maxWidth: 360 }}>
+            <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+            <TextField label="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+            <Button variant="contained" type="submit">
+              Login
+            </Button>
+            <Divider>or</Divider>
+            <Button variant="outlined" onClick={() => handleProvider('Google')}>
+              Login with Google
+            </Button>
+            <Button variant="outlined" onClick={() => handleProvider('Facebook')}>
+              Login with Facebook
+            </Button>
+          </Stack>
+        )}
+      </Box>
     </div>
   );
 }

--- a/src/LoginPage.test.js
+++ b/src/LoginPage.test.js
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import LoginPage from './LoginPage';
 
-test('renders the login page', () => {
+test('renders login form with provider buttons', () => {
   render(<LoginPage />);
   const heading = screen.getByRole('heading', { name: /login/i });
   expect(heading).toBeInTheDocument();
+  expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /facebook/i })).toBeInTheDocument();
 });

--- a/src/index.js
+++ b/src/index.js
@@ -3,16 +3,25 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import PodcastPage from './PodcastPage';
+import LoginPage from './LoginPage';
+import SignupPage from './SignupPage';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+
+const path = window.location.pathname;
+let PageComponent = App;
+if (path === '/podcast.html') {
+  PageComponent = PodcastPage;
+} else if (path === '/login.html') {
+  PageComponent = LoginPage;
+} else if (path === '/signup.html') {
+  PageComponent = SignupPage;
+}
+
 root.render(
   <React.StrictMode>
-    {window.location.pathname === '/podcast.html' ? (
-      <PodcastPage />
-    ) : (
-      <App />
-    )}
+    <PageComponent />
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- enhance `/login.html` and `/signup.html` to load the React app
- route `/login.html` and `/signup.html` in `index.js`
- implement a simple login page with name/email form and Google/Facebook buttons
- update tests for the login page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*