### PR TITLE
Add Stripe checkout integration via backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,17 @@ This project is a React application. The sections below outline prerequisites, s
 
 ## Environment variables
 
-The app expects two environment variables to reach the Supabase backend:
+The app expects environment variables to reach both the Supabase backend and your custom backend on Render:
 
 ```bash
 REACT_APP_SUPABASE_URL=<your-supabase-url>
 REACT_APP_SUPABASE_KEY=<your-supabase-key>
+REACT_APP_BACKEND_URL=<your-backend-url>
 ```
 
 You can place them in a local `.env` file or configure them in your deployment environment.
+
+The `REACT_APP_BACKEND_URL` variable should point to your deployed backend on Render (e.g. `https://osbackend-zl1h.onrender.com`). The app uses this URL to create Stripe Checkout sessions when visitors click **Subscribe** in the call-to-action section.
 
 ## Deploying to Netlify
 

--- a/src/components/CTASection.js
+++ b/src/components/CTASection.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, Typography, Button } from '@mui/material';
+import { Box, Typography, Button, Stack } from '@mui/material';
+import { createCheckoutSession } from '../stripeService';
 
 export default function CTASection() {
   return (
@@ -34,32 +35,56 @@ export default function CTASection() {
       }}>
         Take the first step toward elite sales performance. Schedule a call with our team to discover how RepSpheres can elevate your results.
       </Typography>
-      <Button
-        variant="contained"
-        href="#contact"
-        size="large"
-        sx={{
-          px: 6,
-          py: 2.2,
-          fontWeight: 700,
-          fontSize: '1.18rem',
-          borderRadius: '30px',
-          background: 'linear-gradient(90deg, #7B42F6 0%, #00ffc6 100%)',
-          boxShadow: '0 4px 24px rgba(123,66,246,0.18)',
-          color: '#fff',
-          transition: 'all 0.22s',
-          textTransform: 'none',
-          '&:hover': {
-            background: 'linear-gradient(90deg, #5B3CFF 0%, #00ffc6 100%)',
-            boxShadow: '0 8px 36px rgba(123,66,246,0.22)',
+      <Stack direction="row" spacing={2}>
+        <Button
+          variant="contained"
+          href="#contact"
+          size="large"
+          sx={{
+            px: 6,
+            py: 2.2,
+            fontWeight: 700,
+            fontSize: '1.18rem',
+            borderRadius: '30px',
+            background: 'linear-gradient(90deg, #7B42F6 0%, #00ffc6 100%)',
+            boxShadow: '0 4px 24px rgba(123,66,246,0.18)',
             color: '#fff',
-            transform: 'translateY(-2px) scale(1.04)'
-          },
-          display: { xs: 'none', md: 'inline-flex' }
-        }}
-      >
-        Schedule a Call
-      </Button>
+            transition: 'all 0.22s',
+            textTransform: 'none',
+            '&:hover': {
+              background: 'linear-gradient(90deg, #5B3CFF 0%, #00ffc6 100%)',
+              boxShadow: '0 8px 36px rgba(123,66,246,0.22)',
+              color: '#fff',
+              transform: 'translateY(-2px) scale(1.04)'
+            },
+            display: { xs: 'none', md: 'inline-flex' }
+          }}
+        >
+          Schedule a Call
+        </Button>
+        <Button
+          variant="outlined"
+          size="large"
+          onClick={createCheckoutSession}
+          sx={{
+            px: 6,
+            py: 2.2,
+            fontWeight: 700,
+            fontSize: '1.18rem',
+            borderRadius: '30px',
+            color: '#00ffc6',
+            borderColor: '#00ffc6',
+            textTransform: 'none',
+            '&:hover': {
+              borderColor: '#5B3CFF',
+              color: '#5B3CFF'
+            },
+            display: { xs: 'none', md: 'inline-flex' }
+          }}
+        >
+          Subscribe
+        </Button>
+      </Stack>
       {/* Sticky mobile CTA */}
       <Box sx={{
         display: { xs: 'flex', md: 'none' },

--- a/src/stripeService.js
+++ b/src/stripeService.js
@@ -1,0 +1,22 @@
+export async function createCheckoutSession() {
+  const backendUrl = process.env.REACT_APP_BACKEND_URL;
+  if (!backendUrl) {
+    console.error('REACT_APP_BACKEND_URL not set');
+    return;
+  }
+  try {
+    const res = await fetch(`${backendUrl}/create-checkout-session`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+    if (!res.ok) throw new Error('Failed to create session');
+    const data = await res.json();
+    if (data.url) {
+      window.location.href = data.url;
+    }
+  } catch (err) {
+    console.error('Checkout error', err);
+  }
+}


### PR DESCRIPTION
## Summary
- integrate CTA section with backend by calling `create-checkout-session`
- add simple Stripe service helper
- document new `REACT_APP_BACKEND_URL` environment variable

## Testing
- `npm test --silent` *(fails: react-scripts not found)*