### PR TITLE
Improve navbar spacing and move theme toggle

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -480,9 +480,9 @@ export default function NavBar() {
           ml: 'auto',
           gap: { xs: 0.5, sm: 1 },
         }}>
-          {/* Auth Buttons - Always visible except on very small screens */}
+          {/* Auth Buttons - hide on extra small screens */}
           <Box sx={{
-            display: 'flex',
+            display: { xs: 'none', sm: 'flex' },
             alignItems: 'center',
           }}>
             <Button

--- a/src/components/ThemeToggle.js
+++ b/src/components/ThemeToggle.js
@@ -35,7 +35,7 @@ export default function ThemeToggle() {
       sx={{
         position: 'fixed',
         bottom: 16,
-        right: 16,
+        left: 16,
         zIndex: 1500,
         color: '#fff',
         backgroundColor: 'rgba(255,255,255,0.15)',


### PR DESCRIPTION
## Summary
- hide auth buttons on extra small screens so the navbar doesn't crowd
- reposition theme toggle to the bottom left of the viewport

## Testing
- `npm test --silent` *(fails: react-scripts not found)*