### PR TITLE
Add admin analytics page and admin nav link

### DIFF
--- a/public/admin-analytics.html
+++ b/public/admin-analytics.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Admin analytics dashboard" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <title>Admin Analytics - RepSpheres</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/AdminAnalyticsPage.js
+++ b/src/AdminAnalyticsPage.js
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Paper,
+} from '@mui/material';
+import NavBar from './components/NavBar';
+import StarryBackground from './components/StarryBackground';
+import OrbContextProvider from './components/OrbContextProvider';
+import { AuthProvider } from './contexts/AuthContext';
+
+/**
+ * AdminAnalyticsPage fetches metrics from the Google Analytics Data API and
+ * displays them in a simple table. The access token and property ID should be
+ * provided via environment variables REACT_APP_GA_ACCESS_TOKEN and
+ * REACT_APP_GA_PROPERTY_ID.
+ */
+export default function AdminAnalyticsPage() {
+  const [report, setReport] = useState(null);
+
+  useEffect(() => {
+    const fetchReport = async () => {
+      const token = process.env.REACT_APP_GA_ACCESS_TOKEN;
+      const propertyId = process.env.REACT_APP_GA_PROPERTY_ID;
+      if (!token || !propertyId) return;
+
+      try {
+        const res = await fetch(
+          `https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({
+              dateRanges: [{ startDate: '7daysAgo', endDate: 'today' }],
+              metrics: [{ name: 'activeUsers' }, { name: 'sessions' }],
+              dimensions: [{ name: 'date' }],
+            }),
+          }
+        );
+
+        if (res.ok) {
+          const data = await res.json();
+          setReport(data);
+        } else {
+          console.error('Failed to fetch analytics', await res.text());
+        }
+      } catch (err) {
+        console.error('Error contacting Google Analytics', err);
+      }
+    };
+
+    fetchReport();
+  }, []);
+
+  const renderTable = () => {
+    if (!report) {
+      return <Typography>Loading analytics…</Typography>;
+    }
+
+    const { dimensionHeaders = [], metricHeaders = [], rows = [] } = report;
+
+    return (
+      <Paper sx={{ mt: 2, overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              {dimensionHeaders.map((h) => (
+                <TableCell key={h.name}>{h.name}</TableCell>
+              ))}
+              {metricHeaders.map((h) => (
+                <TableCell key={h.name}>{h.name}</TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row, i) => (
+              <TableRow key={i}>
+                {row.dimensionValues.map((d, j) => (
+                  <TableCell key={`d-${j}`}>{d.value}</TableCell>
+                ))}
+                {row.metricValues.map((m, j) => (
+                  <TableCell key={`m-${j}`}>{m.value}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    );
+  };
+
+  return (
+    <OrbContextProvider>
+      <AuthProvider>
+        <StarryBackground />
+        <NavBar />
+        <Box sx={{ p: 2, color: '#fff' }}>
+          <Typography variant="h4" gutterBottom>
+            Analytics Dashboard
+          </Typography>
+          {renderTable()}
+        </Box>
+      </AuthProvider>
+    </OrbContextProvider>
+  );
+}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -7,7 +7,8 @@ jest.mock('./contexts/AuthContext', () => ({
     user: null,
     loading: false,
     signInWithGoogle: jest.fn(),
-    signOut: jest.fn()
+    signOut: jest.fn(),
+    isAdmin: false
   }),
   AuthProvider: ({ children }) => children
 }));

--- a/src/LoginPage.test.js
+++ b/src/LoginPage.test.js
@@ -8,7 +8,8 @@ jest.mock('./contexts/AuthContext', () => ({
     loading: false,
     signInWithGoogle: jest.fn(),
     signInWithFacebook: jest.fn(),
-    signOut: jest.fn()
+    signOut: jest.fn(),
+    isAdmin: false
   }),
   AuthProvider: ({ children }) => children
 }));

--- a/src/PodcastPage.test.js
+++ b/src/PodcastPage.test.js
@@ -7,7 +7,8 @@ jest.mock('./contexts/AuthContext', () => ({
     user: null,
     loading: false,
     signInWithGoogle: jest.fn(),
-    signOut: jest.fn()
+    signOut: jest.fn(),
+    isAdmin: false
   }),
   AuthProvider: ({ children }) => children
 }));

--- a/src/SignupPage.test.js
+++ b/src/SignupPage.test.js
@@ -8,7 +8,8 @@ jest.mock('./contexts/AuthContext', () => ({
     loading: false,
     signInWithGoogle: jest.fn(),
     signInWithFacebook: jest.fn(),
-    signOut: jest.fn()
+    signOut: jest.fn(),
+    isAdmin: false
   }),
   AuthProvider: ({ children }) => children
 }));

--- a/src/__mocks__/authContextMock.js
+++ b/src/__mocks__/authContextMock.js
@@ -3,7 +3,8 @@ export const mockAuthContext = {
   user: null,
   loading: false,
   signInWithGoogle: jest.fn(),
-  signOut: jest.fn()
+  signOut: jest.fn(),
+  isAdmin: false
 };
 
 // Mock for useAuth hook

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -37,7 +37,7 @@ import AuthModal from './AuthModal';
 const ACCENT_COLOR = '#00ffc6';
 
 // Main navigation links
-const getNavLinks = (currentUrl) => {
+const getNavLinks = (currentUrl, isAdmin) => {
   const links = [
     { 
       key: 'insights',
@@ -65,6 +65,15 @@ const getNavLinks = (currentUrl) => {
       icon: <PodcastsIcon fontSize="small" sx={{ color: ACCENT_COLOR }} />
     },
   ];
+
+  if (isAdmin) {
+    links.push({
+      key: 'analytics',
+      label: 'Analytics',
+      href: '/admin-analytics',
+      icon: <InsightsIcon fontSize="small" sx={{ color: ACCENT_COLOR }} />,
+    });
+  }
 
   // Show Linguistics link only if not on the linguistics page
   if (!currentUrl.includes('/linguistics')) {
@@ -106,13 +115,13 @@ export default function NavBar() {
   const isXXS = useMediaQuery('(max-width:320px)');
   
   // Get authentication context
-  const { user, loading, signInWithGoogle, signInWithFacebook, signOut } = useAuth();
+  const { user, loading, signInWithGoogle, signInWithFacebook, signOut, isAdmin } = useAuth();
   
   // Get current URL to determine which page we're on
   const currentUrl = typeof window !== 'undefined' ? window.location.href : '';
 
   // Get navigation links based on current page
-  const navLinks = getNavLinks(currentUrl);
+  const navLinks = getNavLinks(currentUrl, isAdmin);
   
   // Get the gradient colors from context
   const { gradientColors } = useOrbContext();

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -14,6 +14,7 @@ export function AuthProvider({ children }) {
   // State for the current user
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   // Function to sign in with Google
   const signInWithGoogle = async () => {
@@ -95,10 +96,30 @@ export function AuthProvider({ children }) {
     initializeAuth();
   }, []);
 
+  // Determine admin status whenever user changes
+  useEffect(() => {
+    if (!user) {
+      setIsAdmin(false);
+      return;
+    }
+    const adminEmails = (process.env.REACT_APP_ADMIN_EMAILS || '')
+      .split(',')
+      .map((e) => e.trim())
+      .filter(Boolean);
+    if (adminEmails.includes(user.email)) {
+      setIsAdmin(true);
+    } else if (user.user_metadata?.role === 'admin') {
+      setIsAdmin(true);
+    } else {
+      setIsAdmin(false);
+    }
+  }, [user]);
+
   // Values to provide through the context
   const value = {
     user,
     loading,
+    isAdmin,
     signInWithGoogle,
     signInWithFacebook,
     signOut,

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import App from './App';
 import PodcastPage from './PodcastPage';
 import LoginPage from './LoginPage';
 import SignupPage from './SignupPage';
+import AdminAnalyticsPage from './AdminAnalyticsPage';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
@@ -17,6 +18,8 @@ if (path === '/podcast.html') {
   PageComponent = LoginPage;
 } else if (path === '/signup.html') {
   PageComponent = SignupPage;
+} else if (path === '/admin-analytics') {
+  PageComponent = AdminAnalyticsPage;
 }
 
 root.render(


### PR DESCRIPTION
## Summary
- add new `AdminAnalyticsPage` component that fetches Google Analytics Data API
- expose admin flag in `AuthContext`
- show analytics link in `NavBar` when user is admin
- map `/admin-analytics` route in `index.js`
- create minimal `admin-analytics.html`
- update tests and mocks for new `isAdmin` field

## Testing
- `npm test --silent` *(fails: react-scripts not found)*