### PR TITLE
Add podcast page hero and layout improvements

### DIFF
--- a/src/PodcastPage.js
+++ b/src/PodcastPage.js
@@ -1,9 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Typography, Container } from '@mui/material';
+import { Box } from '@mui/material';
 import NavBar from './components/NavBar';
 import StarryBackground from './components/StarryBackground';
 import OrbContextProvider from './components/OrbContextProvider';
 import Podcasts from './components/Podcasts';
+import PodcastHero from './components/PodcastHero';
+import Footer from './components/Footer';
+import ThemeToggle from './components/ThemeToggle';
 
 const SUPABASE_URL = process.env.REACT_APP_SUPABASE_URL;
 const SUPABASE_KEY = process.env.REACT_APP_SUPABASE_KEY;
@@ -37,24 +40,12 @@ export default function PodcastPage() {
     <OrbContextProvider>
       <StarryBackground />
       <NavBar />
-      <Box
-        sx={{
-          py: { xs: 8, md: 12 },
-          background: 'linear-gradient(135deg, #7B42F6 0%, #00ffc6 100%)',
-          color: '#fff',
-          textAlign: 'center',
-        }}
-      >
-        <Container maxWidth="md">
-          <Typography variant="h2" fontWeight={800} gutterBottom>
-            RepSpheres Podcast
-          </Typography>
-          <Typography variant="h6" sx={{ color: 'rgba(255,255,255,0.9)' }}>
-            Insights, interviews and strategies for elite sales reps.
-          </Typography>
-        </Container>
+      <PodcastHero />
+      <Box id="episodes">
+        <Podcasts episodes={episodes} />
       </Box>
-      <Podcasts episodes={episodes} />
+      <Footer />
+      <ThemeToggle />
     </OrbContextProvider>
   );
 }

--- a/src/components/PodcastHero.js
+++ b/src/components/PodcastHero.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Box, Container, Typography, Button } from '@mui/material';
+import PodcastsIcon from '@mui/icons-material/Podcasts';
+
+export default function PodcastHero() {
+  return (
+    <Box
+      sx={{
+        py: { xs: 10, md: 16 },
+        textAlign: 'center',
+        background: 'linear-gradient(135deg, #7B42F6 0%, #00ffc6 100%)',
+        color: '#fff',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <Container maxWidth="md">
+        <PodcastsIcon sx={{ fontSize: { xs: 80, md: 120 }, mb: 2 }} />
+        <Typography variant="h2" component="h1" fontWeight={800} gutterBottom>
+          RepSpheres Podcast
+        </Typography>
+        <Typography variant="h6" sx={{ color: 'rgba(255,255,255,0.9)', mb: 4 }}>
+          Insights, interviews and strategies for elite sales teams
+        </Typography>
+        <Button
+          variant="contained"
+          color="secondary"
+          size="large"
+          href="#episodes"
+          sx={{
+            fontWeight: 700,
+            borderRadius: '50px',
+            px: 5,
+            py: 1.5,
+            background: '#18182b',
+            '&:hover': {
+              background: '#0b0b20',
+            },
+          }}
+        >
+          Explore Episodes
+        </Button>
+      </Container>
+    </Box>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 
 const path = window.location.pathname;
 let PageComponent = App;
-if (path === '/podcast.html') {
+if (path === '/podcast.html' || path === '/podcast') {
   PageComponent = PodcastPage;
 } else if (path === '/login.html') {
   PageComponent = LoginPage;


### PR DESCRIPTION
## Summary
- create `PodcastHero` component
- enhance `PodcastPage` with hero, footer and theme toggle
- support `/podcast` route in page selection

## Testing
- `npm test --silent` *(fails: react-scripts not found)*