### PR TITLE
Improve theme toggle state handling

### DIFF
--- a/src/components/ThemeToggle.js
+++ b/src/components/ThemeToggle.js
@@ -8,23 +8,24 @@ import InvertColorsIcon from '@mui/icons-material/InvertColors';
 export default function ThemeToggle() {
   const [active, setActive] = useState(false);
 
+  // Initialize from localStorage
   useEffect(() => {
     const stored = localStorage.getItem('invertedTheme') === 'true';
     setActive(stored);
-    if (stored) {
-      document.body.classList.add('inverted-theme');
-    }
   }, []);
 
-  const handleToggle = () => {
-    const newVal = !active;
-    setActive(newVal);
-    if (newVal) {
+  // Update DOM and storage whenever active changes
+  useEffect(() => {
+    if (active) {
       document.body.classList.add('inverted-theme');
     } else {
       document.body.classList.remove('inverted-theme');
     }
-    localStorage.setItem('invertedTheme', newVal);
+    localStorage.setItem('invertedTheme', active);
+  }, [active]);
+
+  const handleToggle = () => {
+    setActive((prev) => !prev);
   };
 
   return (

--- a/src/components/ThemeToggle.test.js
+++ b/src/components/ThemeToggle.test.js
@@ -1,0 +1,24 @@
+import { render, fireEvent } from '@testing-library/react';
+import ThemeToggle from './ThemeToggle';
+
+beforeEach(() => {
+  localStorage.clear();
+  document.body.className = '';
+});
+
+test('toggles inverted-theme class on click', () => {
+  const { getByLabelText } = render(<ThemeToggle />);
+  const btn = getByLabelText(/toggle color theme/i);
+  expect(document.body.classList.contains('inverted-theme')).toBe(false);
+  fireEvent.click(btn);
+  expect(document.body.classList.contains('inverted-theme')).toBe(true);
+  fireEvent.click(btn);
+  expect(document.body.classList.contains('inverted-theme')).toBe(false);
+});
+
+test('initializes from localStorage', () => {
+  localStorage.setItem('invertedTheme', 'true');
+  const { unmount } = render(<ThemeToggle />);
+  expect(document.body.classList.contains('inverted-theme')).toBe(true);
+  unmount();
+});


### PR DESCRIPTION
## Summary
- sync `ThemeToggle` state with `localStorage` via an effect
- update DOM whenever `active` changes
- test the theme toggle

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*